### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ Here's the same example with _tilakone_:
   {::tk/states  count-ab-states
    ::tk/action! (fn [{::tk/keys [action] :as fsm}]
                   (case action
-                    :inc-val (update fsm :count inc)))
-   ::tk/state   :start
-   :count       0})
+                    :inc-val (update-in fsm [::tk/process :count] inc)))
+   ::tk/state :start
+   :count 0})
 
 ; Lets apply same inputs to our FSM:
 


### PR DESCRIPTION
`:count` is placed in `(-> fsm ::tk/process)` and not `fsm` itself.

Without the change:
```clojure
(->> ["abaaabc" "aaacb" "bbbcab"]
     (map (partial reduce tk/apply-signal count-ab))
     (map :count))

Error printing return value (NullPointerException) at clojure.lang.Numbers/ops (Numbers.java:1095).
Cannot invoke "Object.getClass()" because "x" is null

```